### PR TITLE
Make Project list UI less ambiguous

### DIFF
--- a/src/main/java/seedu/address/ui/ProjectCard.java
+++ b/src/main/java/seedu/address/ui/ProjectCard.java
@@ -40,8 +40,8 @@ public class ProjectCard extends UiPart<Region> {
         this.project = project;
         id.setText(displayedIndex + ". ");
         name.setText(project.getProjectName().projectName);
-        client.setText(project.getClient().client);
-        deadline.setText(project.getDeadline().deadline);
+        client.setText("Client: " + project.getClient().client);
+        deadline.setText("Deadline: " + project.getDeadline().deadline);
     }
 
     @Override

--- a/src/main/resources/view/ProjectListPanel.fxml
+++ b/src/main/resources/view/ProjectListPanel.fxml
@@ -3,6 +3,8 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.control.Label?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="projectListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
Shows
"Client:" and "Deadline:" before the respective fields.